### PR TITLE
add option to stop iterations on perplexity convergence via `max_iter` and `perp_tol` parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ lda/_lda.c
 
 # Project-specific
 .testrepository
+
+# pycharm ide
+.idea

--- a/lda/tests/test_lda_reuters.py
+++ b/lda/tests/test_lda_reuters.py
@@ -102,3 +102,26 @@ class TestLDANewsReuters(oslotest.base.BaseTestCase):
         self.assertIsNotNone(doc_topic_new)
         self.assertLess(model_new.loglikelihood(), model.loglikelihood())
         self.assertFalse((doc_topic_new == doc_topic).all())
+
+    def test_lda_max_iter(self):
+        dtm = self.dtm
+        model = self.model
+        doc_topic = self.doc_topic
+        n_topics = self.n_topics
+        random_seed = self.random_seed
+
+        # fit a new model with high max_iter and high perp_tol so that it will definitely stop before max_iter is
+        # reached
+        max_iter = 10000
+        perp_tol = 30
+        perp_window = 10
+        model_new = lda.LDA(n_topics=n_topics, max_iter=max_iter,
+                            perp_tol=perp_tol, perp_window=perp_window,
+                            random_state=random_seed)
+        doc_topic_new = model_new.fit_transform(dtm)
+        self.assertIsNotNone(model_new)
+        self.assertIsNotNone(doc_topic_new)
+        # number of recorded LLs must be at least `perp_window`
+        self.assertGreaterEqual(len(model_new.loglikelihoods_), perp_window)
+        # more iterations and hence better LL
+        self.assertGreater(model_new.loglikelihood(), model.loglikelihood())


### PR DESCRIPTION
I added new parameters that allow to automatically stop the sampling iterations when perplexity convergence is reached. This speeds up fitting the model.
* `max_iter` allows to set the maximum number of iterations and enables the convergence check
* `perp_window` sets how many perplexity values will be recorded for a rolling SD
* `perp_tol` sets the threshold for the rolling SD
If the SD of the perplexity values for the last `perp_window` iterations is below `perp_tol` or `max_iter` is reached, stop the sampling process.