### PR TITLE
Hyperlink DOI to preferred resolver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,5 +146,5 @@ lda is licensed under Version 2.0 of the Mozilla Public License.
     :alt: travis-ci build status
 
 .. |zenodo| image:: https://zenodo.org/badge/doi/10.5281/zenodo.57927.svg
-    :target: http://dx.doi.org/10.5281/zenodo.57927
+    :target: https://doi.org/10.5281/zenodo.57927
     :alt: Zenodo citation


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well.

Cheers!