### PR TITLE
Add cibuildwheel

### DIFF
--- a/lda/tests/test_lda_sparse.py
+++ b/lda/tests/test_lda_sparse.py
@@ -51,6 +51,6 @@ class TestLDASparse(oslotest.base.BaseTestCase):
         np.testing.assert_array_almost_equal(model.topic_word_.sum(axis=1), np.ones(K))
 
     def test_lda_sparse_error_float(self):
-        dtm = self.dtm.astype(np.float)
+        dtm = self.dtm.astype(float)
         model = self.model
         self.assertRaises(ValueError, model.transform, dtm)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,13 @@ flake8 = "^5.0.1"
 meson-python = "^0.14.0"
 cython = "^3.0.3"
 ninja = "^1.11.1.1"
+cibuildwheel = "^2.16.2"
+
+[tool.cibuildwheel]
+build = "cp39-* cp310-* cp311-* cp312-*"
+skip = ["pp*", "*i686", "*win32"]
+test-requires = ["oslotest", "scipy", "setuptools"]
+test-command = "python -m unittest discover -s {project}/lda/tests"
 
 [build-system]
 requires = ["poetry-core", "cython", "meson-python", "ninja"]


### PR DESCRIPTION
This PR introduces [cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/) to build wheels for different platforms (i.e. Windows, Linux and macOS).

I'll add a GitHub Actions workflow in the next PR where this can actually be used, but you can try it out locally by running:

```
$ cibuildwheel --platform linux
```

(Assuming you have installed build dependencies with `poetry install --only build --no-root`)

Note that specifying `macos` or `windows` as platform only works on that operating system, but `linux` works on all three, as long as Docker/Podman is installed.

This will produce 8 wheels:

```
$ tree wheelhouse/
wheelhouse/
├── lda-2.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
├── lda-2.0.0-cp310-cp310-musllinux_1_1_x86_64.whl
├── lda-2.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
├── lda-2.0.0-cp311-cp311-musllinux_1_1_x86_64.whl
├── lda-2.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
├── lda-2.0.0-cp312-cp312-musllinux_1_1_x86_64.whl
├── lda-2.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
└── lda-2.0.0-cp39-cp39-musllinux_1_1_x86_64.whl
```