### PR TITLE
Construct nzw in fortran order to reduce cache misses in hot loops.

### DIFF
--- a/lda/_lda.pyx
+++ b/lda/_lda.pyx
@@ -37,7 +37,7 @@ cdef int searchsorted(double* arr, int length, double value) nogil:
     return imin
 
 
-def _sample_topics(int[:] WS, int[:] DS, int[:] ZS, int[:, :] nzw, int[:, :] ndz, int[:] nz,
+def _sample_topics(int[:] WS, int[:] DS, int[:] ZS, int[::1, :] nzw, int[:, ::1] ndz, int[:] nz,
                    double[:] alpha, double[:] eta, double[:] rands):
     cdef int i, k, w, d, z, z_new
     cdef double r, dist_cum
@@ -78,7 +78,7 @@ def _sample_topics(int[:] WS, int[:] DS, int[:] ZS, int[:, :] nzw, int[:, :] ndz
         free(dist_sum)
 
 
-cpdef double _loglikelihood(int[:, :] nzw, int[:, :] ndz, int[:] nz, int[:] nd, double alpha, double eta) nogil:
+cpdef double _loglikelihood(int[::1, :] nzw, int[:, ::1] ndz, int[:] nz, int[:] nd, double alpha, double eta) nogil:
     cdef int k, d
     cdef int D = ndz.shape[0]
     cdef int n_topics = ndz.shape[1]

--- a/lda/lda.py
+++ b/lda/lda.py
@@ -276,8 +276,8 @@ class LDA:
         logger.info("n_topics: {}".format(n_topics))
         logger.info("n_iter: {}".format(n_iter))
 
-        self.nzw_ = nzw_ = np.zeros((n_topics, W), dtype=np.intc)
-        self.ndz_ = ndz_ = np.zeros((D, n_topics), dtype=np.intc)
+        self.nzw_ = nzw_ = np.zeros((n_topics, W), dtype=np.intc, order="F")
+        self.ndz_ = ndz_ = np.zeros((D, n_topics), dtype=np.intc, order="C")
         self.nz_ = nz_ = np.zeros(n_topics, dtype=np.intc)
 
         self.WS, self.DS = WS, DS = lda.utils.matrix_to_lists(X)


### PR DESCRIPTION
Construct nzw in fortran order to reduce cache misses in hot loops. as it is always iterater over in the topic direction.

This improves the speed of:
  - _sample_topics
  - _loglikelihood
  - ldac2dtm

Benchmark script:

    $ cat bench_lda_fast.py #!/usr/bin/python3

    import os import sys import time

    import lda import lda.utils

    ldac_fn = sys.argv[1] t0 = time.time() dtm = lda.utils.ldac2dtm(open(ldac_fn), offset=0) print("ldac2dtm took: {} seconds".format(time.time() - t0)) t1 = time.time() n_iter = 100 n_topics = 100 random_seed = 1 model = lda.LDA(n_topics=n_topics, n_iter=n_iter, random_state=random_seed) print("Model construction took: {} seconds".format(time.time() - t1)) t2 = time.time() doc_topic = model.fit_transform(dtm) print("Running model took: {} seconds".format(time.time() - t2)) print("Total: {} seconds".format(time.time() - t0))

Original code on reuters.ldac:

    $ python bench_lda_fast.py ../lda/tests/reuters.ldac ldac2dtm took: 0.6914153099060059 seconds Model construction took: 0.0010924339294433594 seconds INFO:lda:n_documents: 395 INFO:lda:vocab_size: 4258 INFO:lda:n_words: 84010 INFO:lda:n_topics: 100 INFO:lda:n_iter: 100 INFO:lda:<0> log likelihood: -1258788 INFO:lda:<10> log likelihood: -734487 INFO:lda:<20> log likelihood: -708068 INFO:lda:<30> log likelihood: -698147 INFO:lda:<40> log likelihood: -691363 INFO:lda:<50> log likelihood: -687491 INFO:lda:<60> log likelihood: -684165 INFO:lda:<70> log likelihood: -682336 INFO:lda:<80> log likelihood: -680400 INFO:lda:<90> log likelihood: -678905 INFO:lda:<99> log likelihood: -676797 Running model took: 8.397335290908813 seconds Total: 9.089883804321289 seconds

New code on reuters.ldac:

    $ python bench_lda_fast.py ../lda/tests/reuters.ldac ldac2dtm took: 0.6984512805938721 seconds Model construction took: 0.001010894775390625 seconds INFO:lda:n_documents: 395 INFO:lda:vocab_size: 4258 INFO:lda:n_words: 84010 INFO:lda:n_topics: 100 INFO:lda:n_iter: 100 INFO:lda:<0> log likelihood: -1258788 INFO:lda:<10> log likelihood: -734487 INFO:lda:<20> log likelihood: -708068 INFO:lda:<30> log likelihood: -698147 INFO:lda:<40> log likelihood: -691363 INFO:lda:<50> log likelihood: -687491 INFO:lda:<60> log likelihood: -684165 INFO:lda:<70> log likelihood: -682336 INFO:lda:<80> log likelihood: -680400 INFO:lda:<90> log likelihood: -678905 INFO:lda:<99> log likelihood: -676797 Running model took: 6.758747816085815 seconds Total: 7.458248615264893 seconds

Old code on a bigger dataset:

    $ python bench_lda_fast.py words_5000_docs_10000_sample_freq_0.05.ldac ldac2dtm took: 29.605552911758423 seconds Model construction took: 0.0009605884552001953 seconds INFO:lda:n_documents: 10000 INFO:lda:vocab_size: 5000 INFO:lda:n_words: 2501477 INFO:lda:n_topics: 100 INFO:lda:n_iter: 100 INFO:lda:<0> log likelihood: -36823892 INFO:lda:<10> log likelihood: -27142527 INFO:lda:<20> log likelihood: -26367123 INFO:lda:<30> log likelihood: -26054203 INFO:lda:<40> log likelihood: -25886173 INFO:lda:<50> log likelihood: -25782106 INFO:lda:<60> log likelihood: -25719117 INFO:lda:<70> log likelihood: -25671755 INFO:lda:<80> log likelihood: -25639538 INFO:lda:<90> log likelihood: -25611296 INFO:lda:<99> log likelihood: -25589423 Running model took: 260.66207242012024 seconds Total: 290.2686412334442 seconds

New code on a bigger dataset:

    $ python bench_lda_fast.py words_5000_docs_10000_sample_freq_0.05.ldac ldac2dtm took: 27.78724980354309 seconds Model construction took: 0.0008566379547119141 seconds INFO:lda:n_documents: 10000 INFO:lda:vocab_size: 5000 INFO:lda:n_words: 2501477 INFO:lda:n_topics: 100 INFO:lda:n_iter: 100 INFO:lda:<0> log likelihood: -36823892 INFO:lda:<10> log likelihood: -27142527 INFO:lda:<20> log likelihood: -26367123 INFO:lda:<30> log likelihood: -26054203 INFO:lda:<40> log likelihood: -25886173 INFO:lda:<50> log likelihood: -25782106 INFO:lda:<60> log likelihood: -25719117 INFO:lda:<70> log likelihood: -25671755 INFO:lda:<80> log likelihood: -25639538 INFO:lda:<90> log likelihood: -25611296 INFO:lda:<99> log likelihood: -25589423 Running model took: 199.07503652572632 seconds Total: 226.86320090293884 seconds

To generate sample datasets:

    generate_ldac() { local n_words="${1}"; local n_docs="${2}"; local sample_freq="${3}";

        awk \
            -v n_words="${n_words}" \
            -v n_docs="${n_docs}" \
            -v sample_freq="${sample_freq}" \
            '
            BEGIN {
                sample_freq_threshold = 1 - sample_freq;

                for ( doc_idx = 0; doc_idx < n_docs; doc_idx++ ) {
                    delete words;
                    current_n_words = 0;

                    for ( word_idx = 0; word_idx < n_words; word_idx++ ) {
                        if ( rand() > sample_freq_threshold ) {
                            # Only retain word if it passes the threshold.
                            words[word_idx] = 1;
                            current_n_words += 1;
                        }
                    }

                    printf "%d",  current_n_words;

                    for ( word_idx in words ) {
                        printf " %d:1", word_idx;
                    }

                printf "\n";
            }
        }' > "words_${n_words}_docs_${n_docs}_sample_freq_${sample_freq}.ldac"
    }

    generate_ldac 5000 10000 0.05